### PR TITLE
Add permissions to create the RDS service linked role

### DIFF
--- a/rds/aurora-cluster/Acornfile
+++ b/rds/aurora-cluster/Acornfile
@@ -1,7 +1,14 @@
 args: {
+	// Name of the root/admin user. Default is admin.
 	adminUsername: "admin"
+	// Name of an additional user to create. This user will have complete access to the database.
+	// If left blank, no additional user will be created.
 	username:      ""
+	// Name of the database instance. Default is instance.
 	dbName:        "instance"
+	// The instance class to use.(medium or large) Default is "small". Not all instances are available in all regions.
+	instanceSize: *"medium" | "large"
+	// Key value pairs of tags to apply to the RDS cluster and all other resources.
 	tags: {}
 }
 
@@ -23,6 +30,7 @@ jobs: "apply": {
 		"/app/cdk.context.json": "@{services.cdk-context.data.cdkContext}"
 		"/app/config.json":      std.toJSON(args)
 	}
+	memory: 1024Mi
 	env: {
 		CDK_DEFAULT_ACCOUNT: "@{services.cdk-context.data.accountID}"
 		CDK_DEFAULT_REGION:  "@{services.cdk-context.data.region}"
@@ -51,6 +59,12 @@ jobs: "apply": {
 			"rds:*",
 		]
 		resources: ["*"]
+	},{
+		apiGroup: "aws.acorn.io"
+		verbs: [
+			"iam:CreateServiceLinkedRole",
+		]
+		resources: ["arn:aws:iam::*:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS"]
 	}]
 	events: ["create", "update", "delete"]
 }

--- a/rds/aurora-cluster/rds.go
+++ b/rds/aurora-cluster/rds.go
@@ -47,6 +47,7 @@ func NewRDSStack(scope constructs.Construct, props *awscdk.StackProps) awscdk.St
 		DefaultDatabaseName: jsii.String(cfg.DatabaseName),
 		CopyTagsToSnapshot:  jsii.Bool(true),
 		Credentials:         creds,
+		RemovalPolicy:       awscdk.RemovalPolicy_DESTROY,
 		InstanceProps: &awsrds.InstanceProps{
 			Vpc:            vpc,
 			SecurityGroups: sgs,

--- a/rds/common.go
+++ b/rds/common.go
@@ -18,6 +18,7 @@ var (
 	SizeMap = map[string]awsec2.InstanceSize{
 		"small":  awsec2.InstanceSize_SMALL,
 		"medium": awsec2.InstanceSize_MEDIUM,
+		"large":  awsec2.InstanceSize_LARGE,
 	}
 	acornTags = map[string]string{
 		"acorn.io/managed":      "true",

--- a/rds/serverless/Acornfile
+++ b/rds/serverless/Acornfile
@@ -1,7 +1,12 @@
 args: {
+	// Name of the root/admin user. Default is admin.
 	adminUsername: "admin"
+	// Name of an additional user to create. This user will have complete access to the database.
+	// If left blank, no additional user will be created.
 	username:      ""
+	// Name of the database instance. Default is instance.
 	dbName:        "instance"
+	// Key value pairs of tags to apply to the RDS cluster and all other resources.
 	tags: {}
 }
 
@@ -51,6 +56,12 @@ jobs: "apply": {
 			"rds:*",
 		]
 		resources: ["*"]
+	},{
+		apiGroup: "aws.acorn.io"
+		verbs: [
+			"iam:CreateServiceLinkedRole",
+		]
+		resources: ["arn:aws:iam::*:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS"]
 	}]
 	events: ["create", "update", "delete"]
 }

--- a/rds/serverless/rds.go
+++ b/rds/serverless/rds.go
@@ -43,6 +43,7 @@ func NewRDSStack(scope constructs.Construct, props *awscdk.StackProps) awscdk.St
 		Engine:              awsrds.DatabaseClusterEngine_AURORA_MYSQL(),
 		DefaultDatabaseName: jsii.String(cfg.DatabaseName),
 		CopyTagsToSnapshot:  jsii.Bool(true),
+		RemovalPolicy:       awscdk.RemovalPolicy_DESTROY,
 		Credentials:         creds,
 		Vpc:                 vpc,
 		Scaling: &awsrds.ServerlessScalingOptions{


### PR DESCRIPTION
Also, fixed bug with the cluster version where instance size wasn't being defined.