### PR TITLE
Add region and format args

### DIFF
--- a/secrets-manager/Acornfile
+++ b/secrets-manager/Acornfile
@@ -3,6 +3,10 @@ args: {
 	arn: ""
 	// Cron based schedule
 	refreshSchedule: ""
+	// Format of the secret. If json the object must be in the format of a JSON object with only string values
+	format: "text" | "json"
+	// Region containing the secret
+	region: ""
 }
 
 services: "secret-manager": {
@@ -16,7 +20,11 @@ jobs: {
 		}
 		schedule: args.refreshSchedule
 		env: {
+			// Default region
 			AWS_REGION: "secret://aws-config/aws-region"
+			// User specified region
+			REGION: args.region
+			FORMAT: args.format
 		}
 		command: [args.arn]
 		permissions: rules: [

--- a/secrets-manager/render.sh
+++ b/secrets-manager/render.sh
@@ -4,7 +4,11 @@ set -e -o pipefail
 arn="${1}"
 
 echo Getting secret value for "$arn"
-data="$(aws --output json secretsmanager get-secret-value --secret-id "${arn}" | jq '{value: .SecretString}')"
+data="$(aws --region "${REGION:-$AWS_REGION}" --output json secretsmanager get-secret-value --secret-id "${arn}" | jq '{value: .SecretString}')"
+
+if [ "$FORMAT" = "json" ]; then
+  data="$(echo "$data" | jq -r .value)"
+fi
 
 cat > /run/secrets/output <<EOF
 services: "secret-manager": {


### PR DESCRIPTION
You can now set the region so that you can fetch a secret from
a region that is not your current running region.

Format can be set to json now which will interpret the secret
value as a map of strings and set them as data keys in your secret
